### PR TITLE
Application "config" arguments

### DIFF
--- a/src/com/wattzap/Main.java
+++ b/src/com/wattzap/Main.java
@@ -86,7 +86,18 @@ public class Main implements Runnable {
             BorderFactory.createEmptyBorder(5, 5, 5, 5));
 
     public static void main(String[] args) {
-		// Debug
+        // set configuration args (user, lang). Whole "list" available in
+        // UserPreferences
+        for (String arg : args) {
+            int i = arg.indexOf('=');
+            if (i > 0) {
+                String key = arg.substring(0, i);
+                String val = arg.substring(i + 1);
+                UserPreferences.setDBValue(key, val);
+            }
+        }
+
+        // Debug
 		Level level = setLogLevel();
 		NativeLibrary.addSearchPath("libvlc", "C:/usr/vlc-2.0.6/");
 		// configure the appender

--- a/src/com/wattzap/MsgBundle.java
+++ b/src/com/wattzap/MsgBundle.java
@@ -30,8 +30,6 @@ public class MsgBundle {
 	private static final Logger logger = LogManager.getLogger("MsgBundle");
 	private static ResourceBundle messages = null;
 
-    // TODO add "anonymous" configChanged listener
-
     public static String getString(String key) {
         if (messages == null) {
     		messages = ResourceBundle.getBundle("MessageBundle",


### PR DESCRIPTION
application arguments in form <key>=<value> "initializes" database settings. Most useful are user=name (user selection), lang=ll-cc (interface language setting). Other in general have config editors.. Are they passed from "splash" screen to java?
